### PR TITLE
Use semaphores for thread synchronization

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@
 # <https://www.gnu.org/licenses/>.
 
 SUBDIRS = tests
-AM_CXXFLAGS = -std=c++11 -Wall -Wextra -pedantic -pthread
+AM_CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic -pthread
 
 bin_PROGRAMS = termux-elf-cleaner
 


### PR DESCRIPTION
Previous implementations may have "array out of bounds" error, which I encountered when doing some package build locally.